### PR TITLE
Anthony/ldap user status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+
+data/
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dist/
 
 data/
 docker-compose.yml
+.DS_STORE
+```

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ dist/
 data/
 docker-compose.yml
 .DS_STORE
-```

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -24,7 +24,7 @@ const (
 	attrUserMail        = "mail"
 	attrUserDisplayName = "displayName"
 
-	// Microsoft Active Directory
+	// Microsoft active directory specific attribute
 	attrUserAccountControl = "userAccountControl"
 )
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -24,7 +24,7 @@ const (
 	attrUserMail        = "mail"
 	attrUserDisplayName = "displayName"
 
-	// Microsoft active directory specific attribute
+	// Microsoft active directory specific attribute.
 	attrUserAccountControl = "userAccountControl"
 )
 


### PR DESCRIPTION
I added support for the accountdisableflag that microsoft uses,  it maybe worth removing the default to enabled (assuming everyone uses MS servers)/

Logic is working, tested using telephone number as a proxy for the userAccountControl flag, as you can see a 514 resulted in disabled and 516 was fine. According to [MS docs](https://learn.microsoft.com/en-us/windows/win32/adschema/a-useraccountcontrol) the flag is stored as an enumeration which should get parsed into an int.

<img width="1334" alt="image" src="https://github.com/ConductorOne/baton-ldap/assets/60042005/477ae7ac-f0ac-4b29-894c-6bc702ab06fb">
<img width="1334" alt="image" src="https://github.com/ConductorOne/baton-ldap/assets/60042005/e8112a0f-465b-4bf9-bf45-53b31db3606e">
<img width="1334" alt="image" src="https://github.com/ConductorOne/baton-ldap/assets/60042005/8e489d23-a13d-4742-ab79-fff861ec5332">
