### PR TITLE
Remove title casing from LDAP connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/spf13/cobra v1.7.0
 	go.uber.org/zap v1.26.0
-	golang.org/x/text v0.13.0
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -79,6 +78,7 @@ require (
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231012201019-e917dd12ba7a // indirect
 	google.golang.org/grpc v1.58.3 // indirect

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -57,7 +57,7 @@ func groupResource(ctx context.Context, group *ldap.Entry) (*v2.Resource, error)
 	groupName := group.GetAttributeValue(attrGroupCommonName)
 
 	resource, err := rs.NewGroupResource(
-		titleCaser.String(groupName),
+		groupName,
 		resourceTypeGroup,
 		group.DN,
 		groupTraitOptions,

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -7,14 +7,10 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/go-ldap/ldap/v3"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var ResourcesPageSize = 50
-
-var titleCaser = cases.Title(language.English)
 
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -50,7 +50,7 @@ func roleResource(ctx context.Context, role *ldap.Entry) (*v2.Resource, error) {
 
 	roleName := role.GetAttributeValue(attrRoleCommonName)
 	resource, err := rs.NewRoleResource(
-		titleCaser.String(roleName),
+		roleName,
 		resourceTypeRole,
 		role.DN,
 		roleTraitOptions,


### PR DESCRIPTION
This PR removes the title caser from the LDAP connector such that group and role names are the same as they are in the ldap resource.