### PR TITLE
Better network retry code.

### DIFF
--- a/pkg/ldap/client.go
+++ b/pkg/ldap/client.go
@@ -122,9 +122,9 @@ func (c *Client) LdapSearch(ctx context.Context, filter string, attrNames []stri
 		scope := ldap.ScopeBaseObject
 
 		// This function gets called on retries, so don't change the value of args, otherwise we don't set scope
-		baseDNOverride_ := baseDNOverride
-		if baseDNOverride_ == "" {
-			baseDNOverride_ = client.baseDN
+		baseDN := baseDNOverride
+		if baseDN == "" {
+			baseDN = client.baseDN
 			scope = ldap.ScopeWholeSubtree
 		}
 
@@ -133,7 +133,7 @@ func (c *Client) LdapSearch(ctx context.Context, filter string, attrNames []stri
 		}
 
 		resp, err := client.conn.Search(&ldap.SearchRequest{
-			BaseDN:       baseDNOverride_,
+			BaseDN:       baseDN,
 			Scope:        scope,
 			DerefAliases: ldap.DerefAlways,
 			Filter:       filter,

--- a/pkg/ldap/client.go
+++ b/pkg/ldap/client.go
@@ -120,8 +120,11 @@ func (c *Client) LdapSearch(ctx context.Context, filter string, attrNames []stri
 			attrNames = []string{"*"}
 		}
 		scope := ldap.ScopeBaseObject
-		if baseDNOverride == "" {
-			baseDNOverride = client.baseDN
+
+		// This function gets called on retries, so don't change the value of args, otherwise we don't set scope
+		baseDNOverride_ := baseDNOverride
+		if baseDNOverride_ == "" {
+			baseDNOverride_ = client.baseDN
 			scope = ldap.ScopeWholeSubtree
 		}
 
@@ -130,7 +133,7 @@ func (c *Client) LdapSearch(ctx context.Context, filter string, attrNames []stri
 		}
 
 		resp, err := client.conn.Search(&ldap.SearchRequest{
-			BaseDN:       baseDNOverride,
+			BaseDN:       baseDNOverride_,
 			Scope:        scope,
 			DerefAliases: ldap.DerefAlways,
 			Filter:       filter,


### PR DESCRIPTION
This fixes recovering from most network errors and even restarting the LDAP server. The only thing it doesn't fix is retrying paginated queries, because the pagination cookie dies when the connection dies.