### PR TITLE
Fixed issue when Grant/Revoke already exisits 

### DIFF
--- a/pkg/ldap/client.go
+++ b/pkg/ldap/client.go
@@ -81,7 +81,7 @@ func (c *Client) getConnection(ctx context.Context, isModify bool, f func(client
 
 			// If we are revoking a user's membership from a resource, and the user is not a member of the resource, we don't want to return an error.
 			// If we are adding a user to a resource, and the user is already a member of the resource, we also don't want to return an error.
-			if (ldap.IsErrorWithCode(err, ldap.LDAPResultEntryAlreadyExists) || ldap.IsErrorWithCode(err, ldap.LDAPResultUnwillingToPerform)) && isModify {
+			if (ldap.IsErrorAnyOf(err, ldap.LDAPResultAttributeOrValueExists, ldap.LDAPResultEntryAlreadyExists, ldap.LDAPResultUnwillingToPerform)) && isModify {
 				return nil
 			}
 			l.Error("baton-ldap: client failed to run function", zap.Error(err))

--- a/pkg/ldap/client.go
+++ b/pkg/ldap/client.go
@@ -81,7 +81,7 @@ func (c *Client) getConnection(ctx context.Context, isModify bool, f func(client
 
 			// If we are revoking a user's membership from a resource, and the user is not a member of the resource, we don't want to return an error.
 			// If we are adding a user to a resource, and the user is already a member of the resource, we also don't want to return an error.
-			if (ldap.IsErrorAnyOf(err, ldap.LDAPResultAttributeOrValueExists, ldap.LDAPResultEntryAlreadyExists, ldap.LDAPResultUnwillingToPerform)) && isModify {
+			if ldap.IsErrorAnyOf(err, ldap.LDAPResultAttributeOrValueExists, ldap.LDAPResultEntryAlreadyExists, ldap.LDAPResultUnwillingToPerform) && isModify {
 				return nil
 			}
 			l.Error("baton-ldap: client failed to run function", zap.Error(err))


### PR DESCRIPTION
Fixed this code by ignoring it when it comes up
`error_description": "rpc error: code = Unknown desc = error: grant failed: ldap-connector: failed to grant group membership to user: LDAP Result Code 20 \"Attribute Or Value Exists\": modify/add: memberUid: value #0 already exists\ntask failed and is non-retryable"`