### PR TITLE
Get group membership faster.

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -129,6 +129,7 @@ func (g *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resou
 	return rv, "", nil, nil
 }
 
+// newGrantFromDN - create a `Grant` from a given group and user distinguished name.
 func newGrantFromDN(resource *v2.Resource, userDN string) *v2.Grant {
 	g := grant.NewGrant(
 		// remove group profile from grant so we're not saving all group memberships in every grant


### PR DESCRIPTION
For members where we already know the DN, just create the grant instead of fetching the user. For group membership by user id, we still have to hit the LDAP server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined process for creating grants, enhancing efficiency by minimizing redundancy.
  
- **Improvements**
	- Simplified grant creation logic, improving maintainability and readability in the handling of user grants. 

- **Error Handling**
	- Maintained robust error logging during user retrieval, ensuring reliability in grant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->