### PR TITLE
Handle cases of LDAP DNs not being cased the same.

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/conductorone/baton-ldap/pkg/ldap"
@@ -71,7 +72,7 @@ func groupResource(ctx context.Context, group *ldap.Entry) (*v2.Resource, error)
 	resource, err := rs.NewGroupResource(
 		groupName,
 		resourceTypeGroup,
-		group.DN,
+		strings.ToLower(group.DN),
 		groupTraitOptions,
 	)
 	if err != nil {
@@ -139,6 +140,7 @@ func (g *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resou
 
 // newGrantFromDN - create a `Grant` from a given group and user distinguished name.
 func newGrantFromDN(resource *v2.Resource, userDN string) *v2.Grant {
+	userDN = strings.ToLower(userDN)
 	g := grant.NewGrant(
 		// remove group profile from grant so we're not saving all group memberships in every grant
 		&v2.Resource{

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -224,7 +225,7 @@ func userResource(ctx context.Context, user *ldap.Entry) (*v2.Resource, error) {
 	resource, err := rs.NewUserResource(
 		displayName,
 		resourceTypeUser,
-		user.DN,
+		strings.ToLower(user.DN),
 		userTraitOptions,
 	)
 	if err != nil {

--- a/scripts/ldif.js
+++ b/scripts/ldif.js
@@ -94,12 +94,12 @@ for (let groupId = 0; groupId < groupCount; groupId++) {
 objectClass: top
 objectClass: groupOfUniqueNames
 cn: othertestgroup${groupIdStr}
-owner: cn=testuser00000@example.com,dc=example,dc=org
+owner: cn=TESTuser00000@example.com,dc=example,dc=org
 `;
 
   for (let userId = 0; userId < usersPerGroup; userId++) {
     const userIdStr = ("00000" + userId).slice(-5);
-    groupStr += `uniquemember: cn=testuser${userIdStr}@example.com,dc=example,dc=org
+    groupStr += `uniquemember: cn=TESTuser${userIdStr}@example.com,dc=EXAMPLE,dc=org
 `;
   }
 
@@ -109,7 +109,7 @@ owner: cn=testuser00000@example.com,dc=example,dc=org
 // Users
 for (let userId = 0; userId < userCount; userId++) {
   const userIdStr = ("00000" + userId).slice(-5);
-  const email = `testuser${userIdStr}@example.com`
+  const email = `testUSER${userIdStr}@example.com`
   write(`dn: cn=${email},dc=example,dc=org
 objectClass: inetOrgPerson
 objectClass: posixAccount


### PR DESCRIPTION
Some LDAP servers seem to have different casing for group membership vs user DNs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved consistency in handling group and user distinguished names (DN) by converting them to lowercase for LDAP operations.
  
- **Bug Fixes**
	- Addressed potential issues with case sensitivity in group and user resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->