### PR TITLE
Add support for LDAP primary groups

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -206,6 +206,10 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, t
 	}
 
 	posixGid := ldapGroup.GetEqualFoldAttributeValue(attrGroupIdPosix)
+	if posixGid == "" {
+		return rv, "", nil, nil
+	}
+
 	nextPage := ""
 	for {
 		var userEntries []*ldap3.Entry

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -27,6 +27,8 @@ const (
 	groupMemberUIDFilter        = `(&` + userFilter + `(uid=%s))`
 	groupMemberCommonNameFilter = `(&` + userFilter + `(cn=%s))`
 
+	groupMemberGidNumber = `(&` + userFilter + `(gidNumber=%s))`
+
 	attrGroupCommonName   = "cn"
 	attrGroupIdPosix      = "gidNumber"
 	attrGroupMember       = "member"
@@ -203,7 +205,50 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, t
 		rv = append(rv, g)
 	}
 
+	posixGid := ldapGroup.GetEqualFoldAttributeValue(attrGroupIdPosix)
+	nextPage := ""
+	for {
+		var userEntries []*ldap3.Entry
+		userEntries, nextPage, err = g.client.LdapSearch(
+			ctx,
+			ldap3.ScopeWholeSubtree,
+			g.userSearchDN,
+			fmt.Sprintf(groupMemberGidNumber, ldap3.EscapeFilter(posixGid)),
+			[]string{"dn"},
+			nextPage, 100,
+		)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("ldap-connector: failed to list group members: %w", err)
+		}
+		for _, userEntry := range userEntries {
+			userDN, err := ldap.CanonicalizeDN(userEntry.DN)
+			if err != nil {
+				l.Error("ldap-connector: invalid user DN", zap.String("user_dn", userEntry.DN), zap.Error(err))
+				continue
+			}
+			g := newGrantFromDN(resource, userDN.String())
+			rv = append(rv, g)
+		}
+		if nextPage == "" {
+			break
+		}
+	}
+
+	rv = uniqueGrants(rv)
+
 	return rv, "", nil, nil
+}
+
+func uniqueGrants(grants []*v2.Grant) []*v2.Grant {
+	seen := make(map[string]struct{})
+	var uniqueGrants []*v2.Grant
+	for _, grant := range grants {
+		if _, ok := seen[grant.Principal.Id.Resource]; !ok {
+			uniqueGrants = append(uniqueGrants, grant)
+			seen[grant.Principal.Id.Resource] = struct{}{}
+		}
+	}
+	return uniqueGrants
 }
 
 // findMember: note this function can return an empty string if the member is not found.

--- a/pkg/connector/testfixtures/primary_groups.ldif
+++ b/pkg/connector/testfixtures/primary_groups.ldif
@@ -1,0 +1,42 @@
+version: 1
+
+dn: ou=groups,dc=example,dc=org
+objectclass: organizationalUnit
+objectclass: top
+ou: groups
+
+dn: cn=staff,ou=groups,dc=example,dc=org
+cn: staff
+gidnumber: 500
+objectclass: posixGroup
+objectclass: top
+
+dn: cn=Humpty Dumpty,ou=users,dc=example,dc=org
+cn:  Humpty Dumpty
+gidnumber: 500
+givenname:  Humpty
+homedirectory: /home/users/ hdumpty
+loginshell: /bin/bash
+objectclass: inetOrgPerson
+objectclass: posixAccount
+objectclass: top
+sn: Dumpty
+uid:  hdumpty
+uidnumber: 1001
+userpassword: {CRYPT}$6$jUJEWaXc$ZK2fUeCkJbhWfIWvXc/Xsjzo3.09DaVWFtFCl1s9qFH
+ I6X7UcPgDJ8SeNNagObmCNurn5VyWsufmBnac/qO601
+
+dn: cn=roger,ou=users,dc=example,dc=org
+cn: roger
+gidnumber: 500
+givenname: Roger Rabbit
+homedirectory: /home/roger
+loginshell: /bin/bash
+objectclass: inetOrgPerson
+objectclass: posixAccount
+objectclass: top
+sn: Rabbit
+uid: roger
+uidnumber: 1000
+userpassword: {CRYPT}$6$Sy1sX75G$/.nlmUpTeW7REXKsdXjRZVXitOrFPk5uEvGs/eC8cXi
+ D0WHlNBT33DDlHlgkP.eiOM5t6VrF1iDj8kYUMPwkT0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced group member retrieval and grant management for improved LDAP functionality.
	- Introduced a new organizational unit and user accounts in the LDAP directory.

- **Bug Fixes**
	- Improved error handling and uniqueness of grants in the group management process.

- **Tests**
	- Added a new test for verifying group management functionalities.

- **Chores**
	- Introduced new LDAP data structure for organizational units and user accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->