### PR TITLE
Retry if we use a bad page token.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,6 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
     - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers


### PR DESCRIPTION
LDAP cookies don't persist across connections, so if we resume a sync with an invalid page token, we error out. This fixes the issue by starting the ldap search from scratch. It retries exactly one time and fails if we get the error again, so it shouldn't cause issues with infinite loops for permission errors.

This is the behavior now if we resume with a bad page token:

```json
{"level":"info","ts":1731973480.263919,"caller":"grpclog/component.go:34","msg":"[core][Server #1]Server created","system":"grpc","grpc_log":true}
{"level":"info","ts":1731973480.264061,"caller":"grpclog/component.go:34","msg":"[core][Server #1 ListenSocket #2]ListenSocket created","system":"grpc","grpc_log":true}
{"level":"info","ts":1731973480.2664409,"caller":"grpclog/component.go:34","msg":"[core]CPU time info is unavailable on non-linux environments.","system":"grpc","grpc_log":true}
{"level":"error","ts":1731973480.304801,"caller":"ldap/client.go:206","msg":"baton-ldap: client failed to search","grpc.start_time":"2024-11-18T15:44:40-08:00","grpc.service":"c1.connector.v2.ResourcesService","grpc.method":"ListResources","peer.address":"127.0.0.1:55023","error":"LDAP Result Code 53 \"Unwilling To Perform\": paged results cookie is invalid or old"}
{"level":"error","ts":1731973480.304827,"caller":"ldap/client.go:93","msg":"baton-ldap: client failed to run function","grpc.start_time":"2024-11-18T15:44:40-08:00","grpc.service":"c1.connector.v2.ResourcesService","grpc.method":"ListResources","peer.address":"127.0.0.1:55023","error":"LDAP Result Code 53 \"Unwilling To Perform\": paged results cookie is invalid or old"}
{"level":"info","ts":1731973480.3048341,"caller":"ldap/client.go:222","msg":"Retrying search without page token","grpc.start_time":"2024-11-18T15:44:40-08:00","grpc.service":"c1.connector.v2.ResourcesService","grpc.method":"ListResources","peer.address":"127.0.0.1:55023","error":"LDAP Result Code 53 \"Unwilling To Perform\": paged results cookie is invalid or old","filter":"(|(objectClass=inetOrgPerson)(objectClass=person)(objectClass=user)(objectClass=organizationalPerson))","search_dn":"dc=example,dc=org"}
{"level":"info","ts":1731973480.5475001,"caller":"sync/syncer.go:581","msg":"Syncing entitlements..."}
{"level":"info","ts":1731973480.672409,"caller":"sync/syncer.go:941","msg":"Syncing grants..."}
{"level":"info","ts":1731973481.616847,"caller":"sync/syncer.go:291","msg":"Sync complete."}
{"level":"info","ts":1731973481.6169112,"caller":"dotc1z/sync_runs.go:435","msg":"Cleaning up old sync data..."}
{"level":"info","ts":1731973481.7084951,"caller":"dotc1z/sync_runs.go:441","msg":"Removed old sync data.","sync_date":"2024-11-18T15:26:46Z","sync_id":"2p2m5ndHhpoxN2VZxUmPTAPv7rF"}
```