### PR TITLE
Check nsAccountLock attribute for user status

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -40,6 +40,9 @@ const (
 	attrUserPrincipalName  = "userPrincipalName"
 	attrUserAccountControl = "userAccountControl"
 	attrUserLastLogon      = "lastLogonTimestamp"
+
+	// FreeIPA (Red Hat Identity) specific attributes
+	attrNSAccountLock      = "nsAccountLock"
 )
 
 var allAttrs = []string{"*", "+"}
@@ -75,8 +78,10 @@ func parseUserNames(user *ldap.Entry) (string, string, string) {
 func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 	userStatus := v2.UserTrait_Status_STATUS_UNSPECIFIED
 
-	// Currently only UserAccountControlFlag from Microsoft is supported
+	// Currently only UserAccountControlFlag from Microsoft or nsAccountLock from FreeIPA is supported
 	userAccountControlFlag := user.GetEqualFoldAttributeValue(attrUserAccountControl)
+	nsAccountLockFlag := user.GetEqualFoldAttributeValue(attrNSAccountLock)
+
 	if userAccountControlFlag != "" {
 		userAccountControlFlag, err := strconv.ParseInt(userAccountControlFlag, 10, 64)
 		if err != nil {
@@ -90,7 +95,12 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 			userStatus = v2.UserTrait_Status_STATUS_DISABLED
 		}
 		return userStatus, nil
+	} else if nsAccountLockFlag == "false" {
+		userStatus = v2.UserTrait_Status_STATUS_ENABLED
+	} else if nsAccountLockFlag == "true" {
+		userStatus = v2.UserTrait_Status_STATUS_DISABLED
 	}
+
 	return userStatus, nil
 }
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -103,10 +103,6 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 			userStatus = v2.UserTrait_Status_STATUS_ENABLED
 		}
 	}
-		userStatus = v2.UserTrait_Status_STATUS_ENABLED
-	} else if nsAccountLockFlag == "true" {
-		userStatus = v2.UserTrait_Status_STATUS_DISABLED
-	}
 
 	return userStatus, nil
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -95,7 +95,14 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 			userStatus = v2.UserTrait_Status_STATUS_DISABLED
 		}
 		return userStatus, nil
-	} else if nsAccountLockFlag == "false" {
+	} else if nsAccountLockFlag != "" {
+		locked, _ := strconv.ParseBool(nsAccountLockFlag)
+		if locked {
+			userStatus = v2.UserTrait_Status_STATUS_DISABLED
+		} else {
+			userStatus = v2.UserTrait_Status_STATUS_ENABLED
+		}
+	}
 		userStatus = v2.UserTrait_Status_STATUS_ENABLED
 	} else if nsAccountLockFlag == "true" {
 		userStatus = v2.UserTrait_Status_STATUS_DISABLED


### PR DESCRIPTION
This collects the nsAccountLock attribute, which is used by FreeIPA and Red Hat Identity to indicate whether an account is disabled
https://docs.redhat.com/en/documentation/red_hat_directory_server/11/html/administration_guide/user_account_management-inactivating_users_and_roles

The userStatus value will be updated accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved user account status determination by incorporating evaluation logic for an additional account lock attribute now supported for FreeIPA environments. This enhancement ensures that users’ account states are more accurately identified as enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->