### PR TITLE
Provision Freeipa and Microsoft AD groups

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -46,6 +46,7 @@ const (
 	attrGroupUniqueMember = "uniqueMember"
 	attrGroupMemberPosix  = "memberUid"
 	attrGroupDescription  = "description"
+	attrGroupObjectGUID   = "objectGUID"
 
 	groupMemberEntitlement = "member"
 )
@@ -431,6 +432,14 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		}
 		username := []string{dn.RDNs[0].Attributes[0].Value}
 		modifyRequest.Add(attrGroupMemberPosix, username)
+	} else if slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") || 
+	          group.GetAttributeValues("attrGroupObjectGUID") != "" {
+		dn, err := ldap.CanonicalizeDN(principal.Id.Resource)
+		if err != nil {
+			return nil, err
+		}
+		username := []string{dn.RDNs[0].Attributes[0].Value}
+		modifyRequest.Add(attrGroupMember, username)
 	} else {
 		principalDNArr := []string{principal.Id.Resource}
 		modifyRequest.Add(attrGroupUniqueMember, principalDNArr)
@@ -473,6 +482,14 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		}
 		username := []string{dn.RDNs[0].Attributes[0].Value}
 		modifyRequest.Delete(attrGroupMemberPosix, username)
+	} else if slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") || 
+		      group.GetAttributeValues("attrGroupObjectGUID") != "" {
+		dn, err := ldap.CanonicalizeDN(principal.Id.Resource)
+		if err != nil {
+			return nil, err
+		}
+		username := []string{dn.RDNs[0].Attributes[0].Value}
+		modifyRequest.Delete(attrGroupMember, username)
 	} else {
 		principalDNArr := []string{principal.Id.Resource}
 		modifyRequest.Delete(attrGroupUniqueMember, principalDNArr)


### PR DESCRIPTION
Adds checks for FreeIPA or Microsoft AD group attributes and modifies the appropriate attribute for membership

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved group membership management now supports flexible handling based on additional attribute criteria, ensuring that membership updates are applied accurately when specific conditions are met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->