### PR TITLE
Provision Freeipa and Microsoft AD groups

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,6 @@ linters:
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - gochecknoinits # Checks that no init functions are present in Go code
     - goconst # Finds repeated strings that could be replaced by a constant

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -471,6 +471,7 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 	}
 
 	groupObjectGUID := parseValue(group, []string{attrGroupObjectGUID})
+	principalDNArr := []string{principal.Id.Resource}
 
 	// TODO: check whether membership is via memberUid, uniqueMember, or member, and modify accordingly
 	if slices.Contains(group.GetAttributeValues("objectClass"), "posixGroup") {
@@ -481,12 +482,7 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		username := []string{dn.RDNs[0].Attributes[0].Value}
 		modifyRequest.Delete(attrGroupMemberPosix, username)
 	} else if slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") || groupObjectGUID != "" {
-		dn, err := ldap.CanonicalizeDN(principal.Id.Resource)
-		if err != nil {
-			return nil, err
-		}
-		username := []string{dn.RDNs[0].Attributes[0].Value}
-		modifyRequest.Delete(attrGroupMember, username)
+		modifyRequest.Delete(attrGroupMember, principalDNArr)
 	} else {
 		principalDNArr := []string{principal.Id.Resource}
 		modifyRequest.Delete(attrGroupUniqueMember, principalDNArr)

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -426,6 +426,7 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	}
 
 	groupObjectGUID := parseValue(group, []string{attrGroupObjectGUID})
+	principalDNArr := []string{principal.Id.Resource}
 
 	if slices.Contains(group.GetAttributeValues("objectClass"), "posixGroup") {
 		dn, err := ldap.CanonicalizeDN(principal.Id.Resource)
@@ -435,14 +436,8 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		username := []string{dn.RDNs[0].Attributes[0].Value}
 		modifyRequest.Add(attrGroupMemberPosix, username)
 	} else if slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") || groupObjectGUID != "" {
-		dn, err := ldap.CanonicalizeDN(principal.Id.Resource)
-		if err != nil {
-			return nil, err
-		}
-		username := []string{dn.RDNs[0].Attributes[0].Value}
-		modifyRequest.Add(attrGroupMember, username)
+		modifyRequest.Add(attrGroupMember, principalDNArr)
 	} else {
-		principalDNArr := []string{principal.Id.Resource}
 		modifyRequest.Add(attrGroupUniqueMember, principalDNArr)
 	}
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -41,8 +41,8 @@ const (
 	attrUserAccountControl = "userAccountControl"
 	attrUserLastLogon      = "lastLogonTimestamp"
 
-	// FreeIPA (Red Hat Identity) specific attributes
-	attrNSAccountLock      = "nsAccountLock"
+	// FreeIPA (Red Hat Identity) specific attributes.
+	attrNSAccountLock = "nsAccountLock"
 )
 
 var allAttrs = []string{"*", "+"}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -40,6 +40,9 @@ const (
 	attrUserPrincipalName  = "userPrincipalName"
 	attrUserAccountControl = "userAccountControl"
 	attrUserLastLogon      = "lastLogonTimestamp"
+
+	// FreeIPA (Red Hat Identity) specific attributes
+	attrNSAccountLock      = "nsAccountLock"
 )
 
 var allAttrs = []string{"*", "+"}
@@ -75,8 +78,10 @@ func parseUserNames(user *ldap.Entry) (string, string, string) {
 func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 	userStatus := v2.UserTrait_Status_STATUS_UNSPECIFIED
 
-	// Currently only UserAccountControlFlag from Microsoft is supported
+	// Currently only UserAccountControlFlag from Microsoft or nsAccountLock from FreeIPA is supported
 	userAccountControlFlag := user.GetEqualFoldAttributeValue(attrUserAccountControl)
+	nsAccountLockFlag := user.GetEqualFoldAttributeValue(attrNSAccountLock)
+
 	if userAccountControlFlag != "" {
 		userAccountControlFlag, err := strconv.ParseInt(userAccountControlFlag, 10, 64)
 		if err != nil {
@@ -90,7 +95,12 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 			userStatus = v2.UserTrait_Status_STATUS_DISABLED
 		}
 		return userStatus, nil
+	} else if nsAccountLockFlag == "false" {
+		userStatus = v2.UserTrait_Status_STATUS_ENABLED
+	} else if nsAccountLockFlag == "true" {
+		userStatus = v2.UserTrait_Status_STATUS_DISABLED
 	}
+
 	return userStatus, nil
 }
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -103,10 +103,6 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 			userStatus = v2.UserTrait_Status_STATUS_ENABLED
 		}
 	}
-		userStatus = v2.UserTrait_Status_STATUS_ENABLED
-	} else if nsAccountLockFlag == "true" {
-		userStatus = v2.UserTrait_Status_STATUS_DISABLED
-	}
 
 	return userStatus, nil
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -95,7 +95,14 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 			userStatus = v2.UserTrait_Status_STATUS_DISABLED
 		}
 		return userStatus, nil
-	} else if nsAccountLockFlag == "false" {
+	} else if nsAccountLockFlag != "" {
+		locked, _ := strconv.ParseBool(nsAccountLockFlag)
+		if locked {
+			userStatus = v2.UserTrait_Status_STATUS_DISABLED
+		} else {
+			userStatus = v2.UserTrait_Status_STATUS_ENABLED
+		}
+	}
 		userStatus = v2.UserTrait_Status_STATUS_ENABLED
 	} else if nsAccountLockFlag == "true" {
 		userStatus = v2.UserTrait_Status_STATUS_DISABLED


### PR DESCRIPTION
Adds checks for FreeIPA or Microsoft AD group attributes and modifies the appropriate attribute for membership

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced group membership management to support more flexible member updates, utilizing the `objectGUID` attribute for better handling of group memberships.
  - Improved user status parsing to include FreeIPA-specific attributes, allowing for more accurate evaluations of user status based on the `nsAccountLock` attribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->