### PR TITLE
Release ldap client connection if error is one we don't care about.

### DIFF
--- a/pkg/ldap/client.go
+++ b/pkg/ldap/client.go
@@ -94,6 +94,7 @@ func (c *Client) getConnection(ctx context.Context, isModify bool, f func(client
 				ldap.LDAPResultUnwillingToPerform,
 				ldap.LDAPResultNoSuchAttribute,
 			) && isModify {
+				cp.Release()
 				return nil
 			}
 			l.Error("baton-ldap: client failed to run function", zap.Error(err))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management to prevent potential connection leaks during certain LDAP modification errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->