### PR TITLE
fix: support groupOfNames and map email→mail for 389-ds compatibility

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -504,7 +504,9 @@ func (g *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		username := []string{dn.RDNs[0].Attributes[0].Value}
 		modifyRequest.Add(attrGroupMemberPosix, username)
 
-	case slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") || groupObjectGUID != "":
+	case slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") ||
+		slices.Contains(group.GetAttributeValues("objectClass"), "groupOfNames") ||
+		groupObjectGUID != "":
 		modifyRequest.Add(attrGroupMember, principalDNArr)
 
 	default:
@@ -553,7 +555,9 @@ func (g *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		username := []string{dn.RDNs[0].Attributes[0].Value}
 		modifyRequest.Delete(attrGroupMemberPosix, username)
 
-	case slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") || groupObjectGUID != "":
+	case slices.Contains(group.GetAttributeValues("objectClass"), "ipausergroup") ||
+		slices.Contains(group.GetAttributeValues("objectClass"), "groupOfNames") ||
+		groupObjectGUID != "":
 		modifyRequest.Delete(attrGroupMember, principalDNArr)
 
 	default:

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -604,6 +604,10 @@ func (o *userResourceType) extractProfile(ctx context.Context, accountInfo *v2.A
 		}, k) {
 			continue
 		}
+		// "mail" is the standard LDAP attribute (RFC 2798); map "email" to it.
+		if k == "email" {
+			k = "mail"
+		}
 
 		attrs = append(attrs, toAttr(k, v))
 	}


### PR DESCRIPTION
## Summary

- **Group grant/revoke**: Added `groupOfNames` to the object class switch in `Grant` and `Revoke` so groups using that class use the `member` attribute instead of falling through to `uniqueMember` (which 389-ds rejects with `Object Class Violation 65`)
- **Account creation**: Remapped the C1 `email` profile key to the standard LDAP `mail` attribute (RFC 2798) in `extractProfile` to prevent `Object Class Violation` on `CreateAccount`

## Linear

EPD-2245: https://linear.app/ductone/issue/EPD-2245

## Test plan

- [ ] Provision group membership to a user on a 389-ds instance — grant should succeed without Object Class Violation
- [ ] Revoke group membership — revoke should succeed
- [ ] Create account via C1 — account should be created with `mail` attribute, no Object Class Violation
- [ ] Verify existing IPA, AD (objectGUID), and posixGroup provisioning paths are unaffected