### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -46,7 +46,7 @@ Here's the set of credentials you'll need when setting up the connector:
 - The username and password of an LDAP account
 - URL of the LDAP server, which can use either `ldap:` or `ldaps:` schemes, and optionally includes a port number
 
-**That's it!** Next, move on to the connector configuration instructions.  
+**Done.** Next, move on to the connector configuration instructions.  
 
 ## Configure the LDAP connector 
 
@@ -184,7 +184,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your LDAP connector is now pulling access data into C1.
+**Done.** Your LDAP connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes depend on the connector — may include one or more of:

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)
- Restore full `ConductorOne*` names (replaces `C1*` abbreviations, e.g. `C1Integration`)
- Restore correct check icon color (`#c937ae`)
- Restore `BATON_PROVISIONING: true` flag in Kubernetes secrets block (with comment)
- Fix connector description to accurately reflect sync/provisioning capabilities

These corrections prevent the sync bot from reintroducing regressions on future runs.