### PR TITLE
fix: mark password as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ var (
 	urlField = field.StringField("url", field.WithDescription(`The URL to connect to. Example: "ldaps://baton.example.com"`))
 
 	baseDNField   = field.StringField("base-dn", field.WithDescription(`The base DN to search from. Example: "DC=baton,DC=example,DC=com"`))
-	passwordField = field.StringField("password", field.WithDescription("The password to bind to the LDAP server"))
+	passwordField = field.StringField("password", field.WithDescription("The password to bind to the LDAP server"), field.WithIsSecret(true))
 	bindDNField   = field.StringField("bind-dn", field.WithDescription("The user DN to bind to the LDAP server"))
 
 	userSearchDNField = field.StringField("user-search-dn",


### PR DESCRIPTION
BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

The credential field(s) are defined in Go via the baton `field` package, which is the source the config schema is derived from (no separate generated config_schema.json is committed in this repo), so adding `field.WithIsSecret(true)` to the field definition is the complete fix.

<!-- stargate: connector-secret-audit-phase11 -->