### PR TITLE
fix: migrate deprecated trait options to resource-level APIs

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -98,9 +98,7 @@ func groupResource(ctx context.Context, group *ldap.Entry) (*v2.Resource, error)
 		profile["gid"] = groupId
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupRsTraitOptions = append(groupRsTraitOptions, rs.WithResourceProfile(profile))
 
 	groupName := group.GetEqualFoldAttributeValue(attrGroupCommonName)
 
@@ -108,7 +106,7 @@ func groupResource(ctx context.Context, group *ldap.Entry) (*v2.Resource, error)
 		groupName,
 		resourceTypeGroup,
 		groupDN,
-		groupTraitOptions,
+		nil,
 		groupRsTraitOptions...,
 	)
 	if err != nil {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -50,16 +50,13 @@ func roleResource(ctx context.Context, role *ldap.Entry) (*v2.Resource, error) {
 		schemaFieldPath:   roleDN,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
-
 	roleName := role.GetEqualFoldAttributeValue(attrRoleCommonName)
 	resource, err := rs.NewRoleResource(
 		roleName,
 		resourceTypeRole,
 		roleDN,
-		roleTraitOptions,
+		nil,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -81,8 +81,8 @@ func parseUserNames(user *ldap.Entry) (string, string, string) {
 	return firstName, lastName, displayName
 }
 
-func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
-	userStatus := v2.UserTrait_Status_STATUS_UNSPECIFIED
+func parseUserStatus(user *ldap.Entry) (v2.Status_ResourceStatus, error) {
+	userStatus := v2.Status_RESOURCE_STATUS_UNSPECIFIED
 
 	// Currently only UserAccountControlFlag from Microsoft or nsAccountLock from FreeIPA is supported
 	userAccountControlFlag := user.GetEqualFoldAttributeValue(attrUserAccountControl)
@@ -96,17 +96,17 @@ func parseUserStatus(user *ldap.Entry) (v2.UserTrait_Status_Status, error) {
 		// Check if the ACCOUNTDISABLE flag (bit 2) is set
 		// https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
 		if (userAccountControlFlag & 2) == 0 {
-			userStatus = v2.UserTrait_Status_STATUS_ENABLED
+			userStatus = v2.Status_RESOURCE_STATUS_ENABLED
 		} else {
-			userStatus = v2.UserTrait_Status_STATUS_DISABLED
+			userStatus = v2.Status_RESOURCE_STATUS_DISABLED
 		}
 		return userStatus, nil
 	} else if nsAccountLockFlag != "" {
 		locked, _ := strconv.ParseBool(nsAccountLockFlag)
 		if locked {
-			userStatus = v2.UserTrait_Status_STATUS_DISABLED
+			userStatus = v2.Status_RESOURCE_STATUS_DISABLED
 		} else {
-			userStatus = v2.UserTrait_Status_STATUS_ENABLED
+			userStatus = v2.Status_RESOURCE_STATUS_ENABLED
 		}
 	}
 
@@ -203,13 +203,15 @@ func userResource(ctx context.Context, user *ldap.Entry) (*v2.Resource, error) {
 	}
 
 	// If the user status is not set, default to enabled
-	if userStatus == v2.UserTrait_Status_STATUS_UNSPECIFIED {
-		userStatus = v2.UserTrait_Status_STATUS_ENABLED
+	if userStatus == v2.Status_RESOURCE_STATUS_UNSPECIFIED {
+		userStatus = v2.Status_RESOURCE_STATUS_ENABLED
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
 		rs.WithEmail(user.GetEqualFoldAttributeValue(attrUserMail), true),
-		rs.WithStatus(userStatus),
+	}
+	resourceOptions := []rs.ResourceOption{
+		rs.WithResourceStatus(userStatus, ""),
 	}
 
 	rawObjectClasses := user.GetEqualFoldAttributeValues("objectClass")
@@ -232,12 +234,12 @@ func userResource(ctx context.Context, user *ldap.Entry) (*v2.Resource, error) {
 		profile["login"] = login
 	}
 
-	userTraitOptions = append(userTraitOptions, rs.WithUserProfile(profile))
+	resourceOptions = append(resourceOptions, rs.WithResourceProfile(profile))
 
 	createdAt := user.GetEqualFoldAttributeValue(attrUserCreatedAt)
 	createTime, err := time.Parse("20060102150405Z0700", createdAt)
 	if err == nil {
-		userTraitOptions = append(userTraitOptions, rs.WithCreatedAt(createTime))
+		resourceOptions = append(resourceOptions, rs.WithResourceCreatedAt(createTime))
 	}
 
 	// Try openldap format first, then fall back to Active Directory's format
@@ -261,6 +263,7 @@ func userResource(ctx context.Context, user *ldap.Entry) (*v2.Resource, error) {
 		resourceTypeUser,
 		userDN,
 		userTraitOptions,
+		resourceOptions...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Fixes `verify / lint` failures from [CI run 29922086144](https://github.com/ConductorOne/baton-ldap/actions/runs/29922086144/job/88929828724) (`SA1019` on deprecated baton-sdk trait helpers).
- Migrates `WithStatus` / `WithUserProfile` / `WithCreatedAt`, `WithGroupProfile`, and `WithRoleProfile` to `WithResourceStatus`, `WithResourceProfile`, and `WithResourceCreatedAt`.
- Updates `parseUserStatus` to return `v2.Status_ResourceStatus`.

## Test plan
- [ ] Confirm `verify / lint` passes on this PR
- [ ] Spot-check synced user/group/role resources still include profile, status, and created_at as expected


Made with [Cursor](https://cursor.com)